### PR TITLE
Trcotton/bss updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,24 +71,24 @@ nodes:
 
 BSS can be populated with a config file:
 ```bash
-./ochami-cli --bss-url http://smd:27778/boot/v1 bss --config bss.yml --add-bootparams
+./ochami-cli --bss-url http://bss:27778/boot/v1 bss --config bss.yml --add-bootparams
 ```
 or updated
 ```bash
-./ochami-cli --bss-url http://smd:27778/boot/v1 bss --config bss.yml --update-bootparams
+./ochami-cli --bss-url http://bss:27778/boot/v1 bss --config bss.yml --update-bootparams
 ```
 
 Individual components can be updates as well, you can choose one or more of the following after specifying `--update-bootparams`; `--kernel`, `--initrd`, `--image`, `--params`.
 Updating the `--image` and `--params` at the same time will result in the `--params` overwriting what is specified in `--image`
 ```bash
-./ochami-cli --bss-url http://smd:27778/boot/v1 bss --update-bootparams --image <image>
-./ochami-cli --bss-url http://smd:27778/boot/v1 bss --update-bootparams --kernel <kernel> --initrd <initrd>
+./ochami-cli --bss-url http://bss:27778/boot/v1 bss --update-bootparams --image <image>
+./ochami-cli --bss-url http://bss:27778/boot/v1 bss --update-bootparams --kernel <kernel> --initrd <initrd>
 ```
 If no `--xname` or `--nid` is specified this will update all the nodes.
 
 You can get the state of BSS with
 ```bash
-./ochami-cli --bss-url http://smd:27778/boot/v1 bss --get-bootparams --format {none|json|yaml}
+./ochami-cli --bss-url http://bss:27778/boot/v1 bss --get-bootparams --format {none|json|yaml}
 ```
 
 Here is an example BSS config file:
@@ -118,18 +118,26 @@ You can include the token when performing actions that require it:
 ```
 
 ## Configuration
-
-Here is an example `config.yaml` to get started using the `ochami-cli` tool:
-
+If SMD and/or BSS are configured to use cacerts and JWTs you can specify these with
 ```bash
-nodes:
-  - name: cg01
-    xname: x1000c1s7b0n0
-    mac: b4:...
-    ipaddr: 172.16.0.1
-  - name: cg02
-    xname: x1000c1s7b1n0
-    mac: b4:...
-    ipaddr: 172.16.0.2
-access-token: eyJhbGciOiJ...
+./ochami-cli --ca-cert --access-token ...
+```
+you can also set environemnt variables for BOTH of these:
+```bash
+export CACERT=/path/to/cacert
+export ACCESS_TOKEN=eyJhbGciOiJ
+```
+
+Other helpful environment variables:
+Skip having to specify `--smd-url`
+```bash
+export SMD_URL=http://smd:27779/hsm/v2
+```
+Skip having to specify `--bss-url`
+```bash
+export BSS_URL=http://bss:27778/boot/v1
+```
+Set NID name prefix (i.e. `nid001`). useful is you want to use something specific to your cluster. Only used on outputing SMD and BSS data.
+```bash
+export CLUSTER_PREFIX="nid"
 ```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,103 @@
 
 The `ochami-cli` tool provides a simple, and direct way to interact with OpenCHAMI services. It is capable of initiating logins for access tokens, managing nodes with SMD, and managing boot scripts/parameters with BSS. The tool is written and Python 3 and requires an interpreter to run.
 
+The tool comes with two other sub-commands `smd` and `bss` to interact with SMD and BSS respectively. 
+
 ## Managing Nodes
 
-The tool comes with two other sub-commands `smd` and `bss` to interact with SMD and BSS respectively. Nodes can be added to SMD using the following command pointing to an instance of SMD:
+### SMD
+Nodes can be added to SMD with a config file using the following command pointing to an instance of SMD:
 
 ```bash
-./ochami-cli smd --config config.yml --url http://smd:27779/hsm/v2
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --config config.yml
+```
+This will create the Node Components and Ethernet Interfaces. If `--fake-discovery` is added to the above and a `bmc_ipaddr` is defined for each node in the config, Redfish Endpoints and ComponentEndpoints will also be created. This will "simulate" hardware discovery. 
+
+Nodes can be added manually with
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --add-node --xname <xname> --nid <nid>
+```
+and deleted with
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --delete-node --xname <xname>
+```
+You can also get the components in SMD with 
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-components --format {none|json|yaml}
+```
+or specify an `xname` or `nid`
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-components --xname <xname>
+```
+
+Ethernet Interfaces can also be added manually with:
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --add-interface --name <name> --xname <xname> --mac <mac> --ipaddr <ipaddr>
+```
+and deleted with
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --delete-interface --xname <xname>
+```
+Get all the EthernetInterfaces:
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-interfaces --format {none|json|yaml}
+```
+or specify an xname
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-interfaces--xname <xname>
+```
+
+You can dump SMD into yaml format that can then be read back into SMD. Useful for saving as a backup or saving updates done with the cmdline.
+```bash
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --dump > nodes.yaml
+```
+
+Here is an example nodes.yaml file:
+```yaml
+nodes:
+  - name: cg01
+    xname: x1000c1s7b0n0
+    mac: b4:...
+    ipaddr: 172.16.0.1
+    bmc_ipaddr: 172.16.100.1
+  - name: cg02
+    xname: x1000c1s7b1n0
+    mac: b4:...
+    ipaddr: 172.16.0.2
+    bmc_ipaddr: 172.16.100.1
+```
+### BSS
+
+BSS can be populated with a config file:
+```bash
+./ochami-cli --bss-url http://smd:27778/boot/v1 bss --config bss.yml --add-bootparams
+```
+or updated
+```bash
+./ochami-cli --bss-url http://smd:27778/boot/v1 bss --config bss.yml --update-bootparams
+```
+
+Individual components can be updates as well, you can choose one or more of the following after specifying `--update-bootparams`; `--kernel`, `--initrd`, `--image`, `--params`.
+Updating the `--image` and `--params` at the same time will result in the `--params` overwriting what is specified in `--image`
+```bash
+./ochami-cli --bss-url http://smd:27778/boot/v1 bss --update-bootparams --image <image>
+./ochami-cli --bss-url http://smd:27778/boot/v1 bss --update-bootparams --kernel <kernel> --initrd <initrd>
+```
+If no `--xname` or `--nid` is specified this will update all the nodes.
+
+You can get the state of BSS with
+```bash
+./ochami-cli --bss-url http://smd:27778/boot/v1 bss --get-bootparams --format {none|json|yaml}
+```
+
+Here is an example BSS config file:
+```yaml
+macs:
+  - a4:bf:01:11:da:b9
+  - a4:bf:01:4c:16:4a
+initrd: 'http://10.100.0.1/boot-images/initramfs.img'
+kernel: 'http://10.100.0.1/boot-images/compute/vmlinuz'
+params: 'nomodeset ro root=nfs:10.100.0.1:/exports/netroot/almalinux8.9:ro,vers=4.2,sec=sys,nolock ip=dhcp console=ttyS0,115200'
 ```
 
 ## Get an Access Token
@@ -17,8 +108,8 @@ The `ochami-cli` is able to initiate the login process with the following comman
 ```
 ./ochami-cli login
 ```
-
-After this command is ran, the `ochami-cli` will first check if you have a valid token either by supplying it with the `--access-token` or `--access-token-file` flags, setting it in the config file, or by setting the `OCHAMI_ACCESS_TOKEN` environment variable. If the token is expired, it will try to fetch a new one by initiating a login flow and open a browser to the login page. You will then be require to sign in with the options available. By default, the tool will save the token to a `.ochami-token` file.
+ 
+After this command is ran, the `ochami-cli` will first check if you have a valid token either by supplying it with the `--access-token` or `--access-token-file` flags, setting it in the config file, or by setting the `ACCESS_TOKEN` environment variable. If the token is expired, it will try to fetch a new one by initiating a login flow and open a browser to the login page. You will then be require to sign in with the options available. By default, the tool will save the token to a `.ochami-token` file.
 
 You can include the token when performing actions that require it:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ The tool comes with two other sub-commands `smd` and `bss` to interact with SMD 
 ## Managing Nodes
 
 ### SMD
-Nodes can be added to SMD with a config file using the following command pointing to an instance of SMD:
+You can skip specifying the `--smd-url` for each command by setting
+```bash
+export SMD_URL=http://smd:27779/hsm/v2
+```
 
+Nodes can be added to SMD with a config file using the following command pointing to an instance of SMD:
 ```bash
 ./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --config config.yml
 ```
@@ -22,9 +26,9 @@ and deleted with
 ```bash
 ./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --delete-node --xname <xname>
 ```
-You can also get the components in SMD with 
+You can also get the components in SMD with. You can specify the format with `--format`. The options are `json` and `yaml`. If not specified the output will be condensed. 
 ```bash
-./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-components --format {none|json|yaml}
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-components --format {json|yaml}
 ```
 or specify an `xname` or `nid`
 ```bash
@@ -41,11 +45,11 @@ and deleted with
 ```
 Get all the EthernetInterfaces:
 ```bash
-./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-interfaces --format {none|json|yaml}
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-interfaces --format {json|yaml}
 ```
 or specify an xname
 ```bash
-./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-interfaces--xname <xname>
+./ochami-cli --smd-url http://smd:27779/hsm/v2 smd --get-interfaces --xname <xname>
 ```
 
 You can dump SMD into yaml format that can then be read back into SMD. Useful for saving as a backup or saving updates done with the cmdline.
@@ -68,6 +72,10 @@ nodes:
     bmc_ipaddr: 172.16.100.1
 ```
 ### BSS
+You can skip specifying `--bss-url` by setting
+```bash
+export BSS_URL=http://bss:27778/boot/v1
+```
 
 BSS can be populated with a config file:
 ```bash
@@ -88,8 +96,9 @@ If no `--xname` or `--nid` is specified this will update all the nodes.
 
 You can get the state of BSS with
 ```bash
-./ochami-cli --bss-url http://bss:27778/boot/v1 bss --get-bootparams --format {none|json|yaml}
+./ochami-cli --bss-url http://bss:27778/boot/v1 bss --get-bootparams --format {json|yaml}
 ```
+You can specify the format with `--format`. The options are `json` and `yaml`. If not specified the output will be condensed.
 
 Here is an example BSS config file:
 ```yaml
@@ -128,7 +137,7 @@ export CACERT=/path/to/cacert
 export ACCESS_TOKEN=eyJhbGciOiJ
 ```
 
-Other helpful environment variables:
+Helpful environment variables:
 Skip having to specify `--smd-url`
 ```bash
 export SMD_URL=http://smd:27779/hsm/v2

--- a/ochami-cli
+++ b/ochami-cli
@@ -17,6 +17,23 @@ access_token = ""
 cacert=True
 
 ############# UTIL ############
+def checkTokenExpired(access_token):
+    import jwt
+    from datetime import datetime, timedelta
+    import sys
+
+    try:
+        decoded = jwt.decode(jwt=access_token, algorithms=["RS256"], options={"verify_signature": False, "verify_aud": False})
+    except jwt.ExpiredSignatureError:
+        print("Token is expired. Generate a new ACCESS_TOKEN")
+        sys.exit(1)
+    else:
+        exp = decoded['exp']
+        now = int(str(datetime.now().timestamp()).split(".")[0])
+        diff = exp - now
+        if diff <= 600:
+            print("Token will expire in " + str(timedelta(seconds=diff)) + ' minutes')
+
 def readConfig(cfile):
     with open(cfile, mode='r') as f:
         cdict = yaml.safe_load(f)
@@ -475,7 +492,7 @@ def main():
 
     # do access token stuff
     if os.getenv("ACCESS_TOKEN"):
-        access_token = os.getenv(f"{os.getenv('ACCESS_TOKEN')}")
+        access_token = os.getenv('ACCESS_TOKEN')
         headers = {"Authorization": f"Bearer {os.getenv('ACCESS_TOKEN')}"}
     if args.access_token:
         access_token = args.access_token
@@ -487,6 +504,7 @@ def main():
                 access_token = f.read()
                 if access_token:
                     headers = {"Authorization": f"Bearer {access_token}"}
+    checkTokenExpired(access_token)
     
     # set CA cert var
     if os.getenv("CACERT"):

--- a/ochami-cli
+++ b/ochami-cli
@@ -124,6 +124,56 @@ def bssPayload(bss):
 
 
 ############# SMD #############
+def dumpSMD(smd_url, headers, cert):
+    data = []
+    smd = getSMDComponents(smd_url, headers, cert, None, None)
+    nid_list = []
+    for s in smd['Components']:
+        if 'NID' in s:
+            nid_list.append(s['NID'])
+    nid_max = max(nid_list)
+    nid_size = len(str(nid_max))
+    for s in smd['Components']:
+        if 'Role' in s:
+            sdict = {}
+            sdict['xname'] = s['ID']
+            sdict['nid'] = s['NID']
+            sdict['name'] = cluster_prefix+str(s['NID']).zfill(nid_size)
+            ei = getSMDInterfaces(smd_url, headers, cert, s['ID'])
+            sdict['mac'] = ei[0]['MACAddress']
+            sdict['ipaddr'] = ei[0]['IPAddresses'][0]['IPAddress']
+            bmc_xname = s['ID'].split('n')[0]
+            ri = getRedfishInterfaces(smd_url, headers, cert, bmc_xname)
+            sdict['bmc_ipaddr'] = ri['RedfishEndpoints'][0]['IPAddress']
+            data.append(sdict)
+    yaml_formatted_str = yaml.dump(data, default_flow_style=False)
+    print(yaml_formatted_str)
+
+def printSMD(smd_url, headers, cert, smd_data, frmt):
+    nodes = {}
+    if frmt == 'json':
+        json_formatted_str = json.dumps(smd_data, indent=2)
+        print(json_formatted_str)
+    elif frmt == 'yaml':
+        yaml_formatted_str = yaml.dump(smd_data, default_flow_style=False)
+        print(yaml_formatted_str)
+    else:
+        if 'Components' in smd_data:
+            for c in smd_data['Components']:
+                if 'Role' in c:
+                    if c['Role'] not in nodes:
+                        nodes[c['Role']] = NodeSet()
+                    nodes[c['Role']].update(c['ID'])
+                else:
+                    if 'BMC' not in nodes:
+                        nodes['BMC'] = NodeSet()
+                    nodes['BMC'].update(c['ID'])
+            for n,v in nodes.items():
+                print(n+': ', v)
+        else:
+            for c in smd_data:
+                print(c['ComponentID'], c['MACAddress'], c['IPAddresses'][0]['IPAddress'])
+
 def addNode(smd_url, headers, cert, xname, nid):
     nc = nodeComponentPayload({'xname': xname, 'nid': nid})
     makeRequest(smd_url+'/State/Components', 'post', headers=headers, cert=cert, jdata=nc)
@@ -154,13 +204,21 @@ def getSMDComponents(smd_url, headers, cert, xname, nid):
     return data
 
 def getSMDInterfaces(smd_url, headers, cert, xname):
-    data = makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='get', headers=headers, cert=cert)
     if not xname:
+        data = makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='get', headers=headers, cert=cert)
         return data
     else:
-        for s in data:
-            if s['ComponentID'] == xname:
-                return s
+        data = makeRequest(url=smd_url+'/Inventory/EthernetInterfaces?ComponentID='+xname, r_type='get', headers=headers, cert=cert)
+        return data
+    return {}
+
+def getRedfishInterfaces(smd_url, headers, cert, xname):
+    if not xname:
+        data = makeRequest(url=smd_url+'/Inventory/RedfishEndpoints', r_type='get', headers=headers, cert=cert)
+        return data
+    else:
+        data = makeRequest(url=smd_url+'/Inventory/RedfishEndpoints?ID='+xname, r_type='get', headers=headers, cert=cert)
+        return data
     return {}
 
 def getNidMacMap(smd_url, headers, cert):
@@ -380,6 +438,8 @@ def setArgs():
     smd.add_argument('--ipaddr',type=str)
     smd.add_argument('--bmc-ipaddr',dest="bmc_ipaddr",type=str)
     smd.add_argument('--nid',type=str)
+    smd.add_argument('--format', type=str)
+    smd.add_argument('--dump', action="store_true", default=False)
     bss = subparser.add_parser('bss')
     bss.add_argument('--config',type=str)
     bss.add_argument('--url', type=str)
@@ -409,7 +469,7 @@ def main():
 
     global cluster_prefix
     if os.getenv('CLUSTER_PREFIX'):
-        cluster_prefix=os.getenv(f"{os.getenv('CLUSTER_PREFIX')}")
+        cluster_prefix=os.getenv('CLUSTER_PREFIX')
     else:
         cluster_prefix='nid'
 
@@ -475,12 +535,12 @@ def main():
             addRedfishEndpoint(smd_url, headers, cacert, args.name, args.xname, args.mac, args.bmc_ipaddr)
         elif args.get_components:
             sc = getSMDComponents(smd_url, headers, cacert, args.xname, args.nid)
-            json_formatted_str = json.dumps(sc, indent=2)
-            print(json_formatted_str)
+            printSMD(smd_url, headers, cacert, sc, args.format) 
         elif args.get_interfaces:
             si = getSMDInterfaces(smd_url, headers, cacert, args.xname)
-            json_formatted_str = json.dumps(si, indent=2)
-            print(json_formatted_str)
+            printSMD(smd_url, headers, cacert, si, args.format)
+        elif args.dump:
+            dumpSMD(smd_url, headers, cacert)
 
     elif args.command == "bss":
         if args.config:

--- a/ochami-cli
+++ b/ochami-cli
@@ -586,7 +586,10 @@ def main():
             deleteBootParams(bss_url, headers, cacert, bss_dict)
         elif args.get_bootparams:
             bss = getBSS(bss_url, headers, cacert)
-            printBSS(smd_url, bss, headers, cacert, args.format)
+            if not bss:
+                print("null")
+            else:
+                printBSS(smd_url, bss, headers, cacert, args.format)
     
     elif args.command == "login":
         url = args.url

--- a/ochami-cli
+++ b/ochami-cli
@@ -187,9 +187,11 @@ def printSMD(smd_url, headers, cert, smd_data, frmt):
                     nodes['BMC'].update(c['ID'])
             for n,v in nodes.items():
                 print(n+': ', v)
-        else:
+        elif type(smd_data) is list:
             for c in smd_data:
                 print(c['ComponentID'], c['MACAddress'], c['IPAddresses'][0]['IPAddress'])
+        elif type(smd_data) is dict:
+            print(json.dumps(smd_data, indent=2))
 
 def addNode(smd_url, headers, cert, xname, nid):
     nc = nodeComponentPayload({'xname': xname, 'nid': nid})

--- a/ochami-cli
+++ b/ochami-cli
@@ -108,6 +108,16 @@ def redfishEndpointPayload(smd):
                 ]
             }
     return sdata
+
+def bssPayload(bss):
+    bdata = {
+                'macs': bss['macs'],
+                'initrd': bss['initrd'],
+                'kernel': bss['kernel'],
+                'params': bss['params']
+            }
+    return bdata
+
 ############# UTIL ############
 
 
@@ -148,12 +158,30 @@ def getSMDInterfaces(smd_url, headers, cert, xname):
             if s['ComponentID'] == xname:
                 return s
     return {}
+
+def getMacFromXname(smd_url, headers, cert, xname):
+    data = makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='get', headers=headers, cert=cert)
+    mac_list = []
+    if not xname:
+        for s in data:
+            if 'MACAddress' in s:
+                mac_list.append(s['MACAddress'])
+    else:
+        for s in data:
+            if s['ComponentID'] == xname:
+                if 'MACAddress' in s:
+                    mac_list.append(s['MACAddress'])
+    return mac_list
 ############# SMD #############
 
 
 ############# BSS #############
 def getBSS(bss_url, headers, cert):
     data = makeRequest(url=bss_url+'/bootparameters', r_type='get', headers=headers, cert=cert)
+    return data
+
+def getBSSfiltered(bss_url, fil, headers, cert):
+    data = makeRequest(url=bss_url+'/bootparameters'+fil, r_type='get', headers=headers, cert=cert)
     return data
 
 def addBootParams(bss_url, headers, cert, bss_data):
@@ -165,6 +193,38 @@ def updateBootParams(bss_url, headers, cert, bss_data):
 
 def deleteBootParams(bss_url, headers, cert, bss_data):
     makeRequest(url=bss_url+'/bootparameters', r_type='delete', jdata=bss_data, headers=headers, cert=cert)
+
+def setBootParams(smd_url, bss_url, headers, cert, xname, image, kernel, initrd, params):
+    macs = getMacFromXname(smd_url, headers, cert, xname)
+    bss_query = '?mac=' + ','.join(macs)
+    bdata = getBSSfiltered(bss_url, bss_query, headers, cert)
+    for b in bdata:
+        if image:
+            param_list = b['params'].split(' ')
+            for p in param_list:
+                if p.startswith('root=nfs') or p.startswith('root=live'):
+                    param_list.remove(p)
+                    img_param = image
+            param_list.append(img_param)
+            new_params = ' '.join(param_list)
+        else:
+            new_params = b['params']
+        if kernel:
+            new_kernel = kernel
+        else:
+            new_kernel = b['kernel']
+        if initrd:
+            new_initrd = initrd
+        else:
+            new_initrd = b['initrd']
+        if params:
+            new_params = params
+        elif not image:
+            new_params = b['params']
+
+        new_bss = bssPayload({'macs': b['macs'], 'kernel': new_kernel, 'initrd': new_initrd, 'params': new_params})
+        updateBootParams(bss_url, headers, cert, new_bss)
+
 ############# BSS #############
 
 ############# AUTH ############
@@ -261,6 +321,11 @@ def setArgs():
     bss.add_argument('--update-bootparams', dest='update_bootparams', action="store_true", default=False)
     bss.add_argument('--delete-bootparams', dest='delete_bootparams', action="store_true", default=False)
     bss.add_argument('--get-bootparams', dest='get_bootparams', action="store_true", default=False)
+    bss.add_argument('--xname', type=str)
+    bss.add_argument('--image', type=str)
+    bss.add_argument('--kernel', type=str)
+    bss.add_argument('--initrd', type=str)
+    bss.add_argument('--params', type=str)
     login = subparser.add_parser('login')
     login.add_argument("--url", type=str, default="http://127.0.0.1:3333/login", help="set the login URL")
     login.add_argument("--target-host", dest='host', type=str, default="127.0.0.1", help="set the target host receive access token")
@@ -295,11 +360,17 @@ def main():
     if args.ca_cert:
         cacert=args.ca_cert
 
+    if os.getenv("SMD_URL"):
+        smd_url = os.getenv('SMD_URL')
+    elif args.smd_url:
+        smd_url = args.smd_url
+
+    if os.getenv("BSS_URL"):
+        bss_url = os.getenv('BSS_URL')
+    elif args.url:
+        bss_url = args.url
+
     if args.command == "smd":
-        if os.getenv("SMD_URL"):
-            smd_url = os.getenv('SMD_URL')
-        elif args.url:
-            smd_url = args.url
         if args.config:
             config = args.config
             cdict = readConfig(config)
@@ -337,18 +408,19 @@ def main():
             json_formatted_str = json.dumps(si, indent=2)
             print(json_formatted_str)
 
-
     elif args.command == "bss":
-        config = args.config
-        if os.getenv("BSS_URL"):
-            bss_url = os.getenv('BSS_URL')
-        elif args.url:
-            bss_url = args.url
-        bss_dict = readConfig(config)
+        if args.config:
+            config = args.config
+            bss_dict = readConfig(config)
+
         if args.add_bootparams:
             addBootParams(bss_url, headers, cacert, bss_dict)
         elif args.update_bootparams:
-            updateBootParams(bss_url, headers, cacert, bss_dict)
+            if args.config:
+                updateBootParams(bss_url, headers, cacert, bss_dict)
+            else:
+                if args.image or args.kernel or args.initrd or args.params:
+                    setBootParams(smd_url, bss_url, headers, cacert, args.xname, args.image, args.kernel, args.initrd, args.params)
         elif args.delete_bootparams:
             deleteBootParams(bss_url, headers, cacert, bss_dict)
         elif args.get_bootparams:

--- a/ochami-cli
+++ b/ochami-cli
@@ -112,35 +112,35 @@ def redfishEndpointPayload(smd):
 
 
 ############# SMD #############
-def addNode(smd_url, headers, xname, nid):
+def addNode(smd_url, headers, cert, xname, nid):
     nc = nodeComponentPayload({'xname': xname, 'nid': nid})
-    makeRequest(smd_url+'/State/Components', 'post', headers, nc)
+    makeRequest(smd_url+'/State/Components', 'post', headers=headers, cert=cert, jdata=nc)
 
-def deleteNode(smd_url, headers, xname):
-    makeRequest(url=smd_url+'/State/Components/'+xname, r_type='delete', headers=headers)
+def deleteNode(smd_url, headers, cert, xname):
+    makeRequest(url=smd_url+'/State/Components/'+xname, r_type='delete', headers=headers, cert=cert)
 
-def addInterface(smd_url, headers, name, xname, mac, ipaddr):
+def addInterface(smd_url, headers, cert, name, xname, mac, ipaddr):
     ei = ethernetInterfacePayload({'name': name,'xname': xname,'mac': mac, 'ipaddr': ipaddr})
-    makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='post', jdata=ei, headers=headers)
+    makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='post', jdata=ei, headers=headers, cert=cert)
 
-def deleteEthernetInterface(smd_url, headers, xname):
-    smd_data = getSMDInterfaces(smd_url, headers, xname)
+def deleteEthernetInterface(smd_url, headers, cert, xname):
+    smd_data = getSMDInterfaces(smd_url, headers, cert, xname)
     if smd_data:
-        makeRequest(url=smd_url+'/Inventory/EthernetInterfaces/'+smd_data['ID'], r_type='delete', headers=headers)
+        makeRequest(url=smd_url+'/Inventory/EthernetInterfaces/'+smd_data['ID'], r_type='delete', headers=headers, cert=cert)
 
-def addRedfishEndpoint(smd_url, headers, name, xname, mac, bmc_ipaddr):
+def addRedfishEndpoint(smd_url, headers, cert, name, xname, mac, bmc_ipaddr):
     re = redfishEndpointPayload({'name': name, 'xname': xname, 'mac': mac, 'bmc_ipaddr': bmc_ipaddr})
-    makeRequest(url=smd_url+'/Inventory/RedfishEndpoints', r_type='post', headers=headers, jdata=re)
+    makeRequest(url=smd_url+'/Inventory/RedfishEndpoints', r_type='post', headers=headers, cert=cert, jdata=re)
 
-def getSMDComponents(smd_url, headers, xname):
+def getSMDComponents(smd_url, headers, cert, xname):
     if not xname:
-        data = makeRequest(url=smd_url+'/State/Components', r_type='get', headers=headers)
+        data = makeRequest(url=smd_url+'/State/Components', r_type='get', headers=headers, cert=cert)
     else:
-        data = makeRequest(url=smd_url+'/State/Components/'+xname, r_type='get', headers=headers)
+        data = makeRequest(url=smd_url+'/State/Components/'+xname, r_type='get', headers=headers, cert=cert)
     return data
 
-def getSMDInterfaces(smd_url, headers, xname):
-    data = makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='get', headers=headers)
+def getSMDInterfaces(smd_url, headers, cert, xname):
+    data = makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='get', headers=headers, cert=cert)
     if not xname:
         return data
     else:
@@ -152,19 +152,19 @@ def getSMDInterfaces(smd_url, headers, xname):
 
 
 ############# BSS #############
-def getBSS(bss_url, headers):
-    data = makeRequest(url=bss_url+'/bootparameters', r_type='get', headers=headers)
+def getBSS(bss_url, headers, cert):
+    data = makeRequest(url=bss_url+'/bootparameters', r_type='get', headers=headers, cert=cert)
     return data
 
-def addBootParams(bss_url, headers, bss_data):
-    makeRequest(url=bss_url+'/bootparameters', r_type='post', jdata=bss_data, headers=headers)
+def addBootParams(bss_url, headers, cert, bss_data):
+    makeRequest(url=bss_url+'/bootparameters', r_type='post', jdata=bss_data, headers=headers, cert=cert)
 
-def updateBootParams(bss_url, headers, bss_data):
-    makeRequest(url=bss_url+'/bootparameters', r_type='delete', jdata=bss_data, headers=headers)
-    makeRequest(url=bss_url+'/bootparameters', r_type='post', jdata=bss_data, headers=headers)
+def updateBootParams(bss_url, headers, cert, bss_data):
+    makeRequest(url=bss_url+'/bootparameters', r_type='delete', jdata=bss_data, headers=headers, cert=cert)
+    makeRequest(url=bss_url+'/bootparameters', r_type='post', jdata=bss_data, headers=headers, cert=cert)
 
-def deleteBootParams(bss_url, headers, bss_data):
-    makeRequest(url=bss_url+'/bootparameters', r_type='delete', jdata=bss_data, headers=headers)
+def deleteBootParams(bss_url, headers, cert, bss_data):
+    makeRequest(url=bss_url+'/bootparameters', r_type='delete', jdata=bss_data, headers=headers, cert=cert)
 ############# BSS #############
 
 ############# AUTH ############
@@ -304,33 +304,33 @@ def main():
                 if args.fake_discovery:
                     print(c)
                     try:
-                        addRedfishEndpoint(smd_url, headers, c['name'], c['xname'], c['mac'], c['bmc_ipaddr'])
+                        addRedfishEndpoint(smd_url, headers, cacert, c['name'], c['xname'], c['mac'], c['bmc_ipaddr'])
                     except Exception as e:
                         print(e)
                 try:
-                    addNode(smd_url, headers, c['xname'], c['nid'])
+                    addNode(smd_url, headers, cacert, c['xname'], c['nid'])
                 except Exception as e:
                     print(e)
                 try:
-                    addInterface(smd_url, headers, c['name'], c['xname'], c['mac'], c['ipaddr'])
+                    addInterface(smd_url, headers, cacert, c['name'], c['xname'], c['mac'], c['ipaddr'])
                 except Exception as e:
                     print(e)
         elif args.add_node:
-            addNode(smd_url, headers, args.xname, args.nid)
+            addNode(smd_url, headers, cacert, args.xname, args.nid)
         elif args.delete_node:
-            deleteNode(smd_url, headers, args.xname)
+            deleteNode(smd_url, headers, cacert, args.xname)
         elif args.add_interface:
-            addInterface(smd_url, headers, args.name, args.xname, args.mac, args.ipaddr)
+            addInterface(smd_url, headers, cacert, args.name, args.xname, args.mac, args.ipaddr)
         elif args.delete_interface:
-            deleteEthernetInterface(smd_url, headers, args.xname)
+            deleteEthernetInterface(smd_url, headers, cacert, args.xname)
         elif args.add_rf_endpoint:
-            addRedfishEndpoint(smd_url, headers, args.name, args.xname, args.mac, args.bmc_ipaddr)
+            addRedfishEndpoint(smd_url, headers, cacert, args.name, args.xname, args.mac, args.bmc_ipaddr)
         elif args.get_components:
-            sc = getSMDComponents(smd_url, headers, args.xname)
+            sc = getSMDComponents(smd_url, headers, cacert, args.xname)
             json_formatted_str = json.dumps(sc, indent=2)
             print(json_formatted_str)
         elif args.get_interfaces:
-            si = getSMDInterfaces(smd_url, headers, args.xname)
+            si = getSMDInterfaces(smd_url, headers, cacert, args.xname)
             json_formatted_str = json.dumps(si, indent=2)
             print(json_formatted_str)
 
@@ -343,13 +343,13 @@ def main():
             bss_url = args.url
         bss_dict = readConfig(config)
         if args.add_bootparams:
-            addBootParams(bss_url, headers, bss_dict)
+            addBootParams(bss_url, headers, cacert, bss_dict)
         elif args.update_bootparams:
-            updateBootParams(bss_url, headers, bss_dict)
+            updateBootParams(bss_url, headers, cacert, bss_dict)
         elif args.delete_bootparams:
-            deleteBootParams(bss_url, headers, bss_dict)
+            deleteBootParams(bss_url, headers, cacert, bss_dict)
         elif args.get_bootparams:
-            bss = getBSS(bss_url, headers)
+            bss = getBSS(bss_url, headers, cacert)
             json_formatted_str = json.dumps(bss, indent=2)
             print(json_formatted_str)
     

--- a/ochami-cli
+++ b/ochami-cli
@@ -12,6 +12,7 @@ import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 access_token = ""
+cacert=True
 
 ############# UTIL ############
 def readConfig(cfile):
@@ -19,13 +20,13 @@ def readConfig(cfile):
         cdict = yaml.safe_load(f)
     return cdict
 
-def makeRequest(url, r_type, headers, jdata=None):
+def makeRequest(url, r_type, headers, jdata=None, cert=cacert):
     if r_type is "get":
-        r = requests.get(url, json = jdata, headers=headers)
+        r = requests.get(url, json = jdata, headers=headers, verify=cert)
     elif r_type is "post":
-        r = requests.post(url, json = jdata, headers=headers)
+        r = requests.post(url, json = jdata, headers=headers, verify=cert)
     elif r_type is "delete":
-        r = requests.delete(url, json = jdata, headers=headers)
+        r = requests.delete(url, json = jdata, headers=headers, verify=cert)
     else:
         print("unrecognized request type: ", r_type)
 
@@ -231,6 +232,7 @@ def setArgs():
     parser = argparse.ArgumentParser()
     parser.add_argument("--access-token", dest="access_token", default="", type=str)
     parser.add_argument("--access-token-file", dest="access_token_file", default=".ochami-token", type=str)
+    parser.add_argument("--ca-cert", dest="ca_cert", type=str, default="", help="set path for CA certificate")
     subparser = parser.add_subparsers(dest='command')
 
     smd = subparser.add_parser('smd')
@@ -266,8 +268,11 @@ def setArgs():
 
 def main():
     global access_token
+    global cacert
     args = setArgs()
     headers = {}
+
+    # do access token stuff
     if os.getenv("OCHAMI_ACCESS_TOKEN"):
         access_token = os.getenv(f"{os.getenv('OCHAMI_ACCESS_TOKEN')}")
         headers = {"Authorization": f"Bearer {os.getenv('OCHAMI_ACCESS_TOKEN')}"}
@@ -281,6 +286,9 @@ def main():
                 access_token = f.read()
                 if access_token:
                     headers = {"Authorization": f"Bearer {access_token}"}
+    
+    # set CA cert var
+    cacert=args.ca_cert
 
     if args.command == "smd":
         if os.getenv("SMD_URL"):

--- a/ochami-cli
+++ b/ochami-cli
@@ -419,9 +419,9 @@ def main():
     
     # set CA cert var
     if os.getenv("CACERT"):
-        cacert = os.getenv(f"{os.getenv('CACERT')}")
+        cacert = os.getenv('CACERT')
     if args.ca_cert:
-        cacert=args.ca_cert
+        cacert = args.ca_cert
 
     if os.getenv("SMD_URL"):
         smd_url = os.getenv('SMD_URL')

--- a/ochami-cli
+++ b/ochami-cli
@@ -11,6 +11,8 @@ import base64
 import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
+from ClusterShell.NodeSet import NodeSet
+
 access_token = ""
 cacert=True
 
@@ -161,6 +163,22 @@ def getSMDInterfaces(smd_url, headers, cert, xname):
                 return s
     return {}
 
+def getNidMacMap(smd_url, headers, cert):
+    data = makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='get', headers=headers, cert=cert)
+    macs_xnames = {}
+    for s in data:
+        macs_xnames[s['MACAddress']] = s['ComponentID']
+
+    macs_nids = {}
+    data = makeRequest(url=smd_url+'/State/Components/', r_type='get', headers=headers, cert=cert)
+    for s in data['Components']:
+        for k,v in macs_xnames.items():
+            if s['ID'] == v:
+                macs_nids[k] = s['NID']
+
+    return macs_nids
+
+
 def getMacFromXname(smd_url, headers, cert, xname):
     data = makeRequest(url=smd_url+'/Inventory/EthernetInterfaces', r_type='get', headers=headers, cert=cert)
     mac_list = []
@@ -192,6 +210,26 @@ def getXnameFromNid(smd_url, headers, cert, nid):
 
 
 ############# BSS #############
+
+def printBSS(smd_url, bss_data, headers, cert):
+    data = getNidMacMap(smd_url, headers, cert)
+    for b in bss_data:
+        pdata = {}
+        pdata['nids'] = NodeSet()
+        pdata['kernel'] = b['kernel']
+        pdata['initrd'] = b['initrd']
+        pdata['params'] = b['params']
+        max_nid = max(data.values())
+        nid_length = len(str(max_nid))
+        for m in b['macs']:
+            nid = cluster_prefix+str(data[m]).zfill(nid_length)
+            pdata['nids'].update(nid)
+        print("nodes:", pdata['nids'])
+        print("kernel: ", pdata['kernel'])
+        print("initrd: ", pdata['initrd'])
+        print("params: ", pdata['params'])
+        print()
+
 def getBSS(bss_url, headers, cert):
     data = makeRequest(url=bss_url+'/bootparameters', r_type='get', headers=headers, cert=cert)
     return data
@@ -358,6 +396,12 @@ def main():
     args = setArgs()
     headers = {}
 
+    global cluster_prefix
+    if os.getenv('CLUSTER_PREFIX'):
+        cluster_prefix=os.getenv(f"{os.getenv('CLUSTER_PREFIX')}")
+    else:
+        cluster_prefix='nid'
+
     # do access token stuff
     if os.getenv("ACCESS_TOKEN"):
         access_token = os.getenv(f"{os.getenv('ACCESS_TOKEN')}")
@@ -444,8 +488,7 @@ def main():
             deleteBootParams(bss_url, headers, cacert, bss_dict)
         elif args.get_bootparams:
             bss = getBSS(bss_url, headers, cacert)
-            json_formatted_str = json.dumps(bss, indent=2)
-            print(json_formatted_str)
+            printBSS(smd_url, bss, headers, cacert)
     
     elif args.command == "login":
         url = args.url

--- a/ochami-cli
+++ b/ochami-cli
@@ -231,7 +231,7 @@ def is_access_token_valid(token: str) -> bool:
 def setArgs():
     parser = argparse.ArgumentParser()
     parser.add_argument("--access-token", dest="access_token", default="", type=str)
-    parser.add_argument("--access-token-file", dest="access_token_file", default=".ochami-token", type=str)
+    parser.add_argument("--access-token-file", dest="access_token_file", default=".access-token", type=str)
     parser.add_argument("--ca-cert", dest="ca_cert", type=str, default="", help="set path for CA certificate")
     subparser = parser.add_subparsers(dest='command')
 
@@ -273,9 +273,9 @@ def main():
     headers = {}
 
     # do access token stuff
-    if os.getenv("OCHAMI_ACCESS_TOKEN"):
-        access_token = os.getenv(f"{os.getenv('OCHAMI_ACCESS_TOKEN')}")
-        headers = {"Authorization": f"Bearer {os.getenv('OCHAMI_ACCESS_TOKEN')}"}
+    if os.getenv("ACCESS_TOKEN"):
+        access_token = os.getenv(f"{os.getenv('ACCESS_TOKEN')}")
+        headers = {"Authorization": f"Bearer {os.getenv('ACCESS_TOKEN')}"}
     if args.access_token:
         access_token = args.access_token
         if access_token:

--- a/ochami-cli
+++ b/ochami-cli
@@ -4,6 +4,7 @@ import yaml
 import argparse
 import json
 import os
+import sys
 import webbrowser
 import urllib
 import uuid
@@ -20,19 +21,19 @@ cacert=True
 def checkTokenExpired(access_token):
     import jwt
     from datetime import datetime, timedelta
-    import sys
 
     try:
         decoded = jwt.decode(jwt=access_token, algorithms=["RS256"], options={"verify_signature": False, "verify_aud": False})
     except jwt.ExpiredSignatureError:
         print("Token is expired. Generate a new ACCESS_TOKEN")
-        sys.exit(1)
+        return False
     else:
         exp = decoded['exp']
         now = int(str(datetime.now().timestamp()).split(".")[0])
         diff = exp - now
         if diff <= 600:
             print("Token will expire in " + str(timedelta(seconds=diff)) + ' minutes')
+        return True
 
 def readConfig(cfile):
     with open(cfile, mode='r') as f:
@@ -506,7 +507,8 @@ def main():
                 access_token = f.read()
                 if access_token:
                     headers = {"Authorization": f"Bearer {access_token}"}
-    checkTokenExpired(access_token)
+    if not checkTokenExpired(access_token):
+        sys.exit(1)
     
     # set CA cert var
     if os.getenv("CACERT"):

--- a/ochami-cli
+++ b/ochami-cli
@@ -507,6 +507,11 @@ def main():
                 access_token = f.read()
                 if access_token:
                     headers = {"Authorization": f"Bearer {access_token}"}
+
+    # Check Token
+    if not access_token:
+        print("ERROR: Neither --access-token, --access-token-file, nor ACCESS_TOKEN were set.")
+        sys.exit(1)
     if not checkTokenExpired(access_token):
         sys.exit(1)
     

--- a/ochami-cli
+++ b/ochami-cli
@@ -290,7 +290,10 @@ def main():
                     headers = {"Authorization": f"Bearer {access_token}"}
     
     # set CA cert var
-    cacert=args.ca_cert
+    if os.getenv("CACERT"):
+        cacert = os.getenv(f"{os.getenv('CACERT')}")
+    if args.ca_cert:
+        cacert=args.ca_cert
 
     if args.command == "smd":
         if os.getenv("SMD_URL"):

--- a/ochami-cli
+++ b/ochami-cli
@@ -211,11 +211,17 @@ def getXnameFromNid(smd_url, headers, cert, nid):
 
 ############# BSS #############
 
-def printBSS(smd_url, bss_data, headers, cert, raw):
+def printBSS(smd_url, bss_data, headers, cert, frmt):
+    for b in bss_data:
+        if 'cloud-init' in b:
+            del b['cloud-init']
     data = getNidMacMap(smd_url, headers, cert)
-    if raw:
+    if frmt == 'json':
         json_formatted_str = json.dumps(bss_data, indent=2)
         print(json_formatted_str)
+    elif frmt == 'yaml':
+        yaml_formatted_str = yaml.dump(bss_data, default_flow_style=False)
+        print(yaml_formatted_str)
     else:
         for b in bss_data:
             pdata = {}
@@ -387,7 +393,7 @@ def setArgs():
     bss.add_argument('--kernel', type=str)
     bss.add_argument('--initrd', type=str)
     bss.add_argument('--params', type=str)
-    bss.add_argument('--raw', action="store_true", default=False)
+    bss.add_argument('--format', type=str)
     login = subparser.add_parser('login')
     login.add_argument("--url", type=str, default="http://127.0.0.1:3333/login", help="set the login URL")
     login.add_argument("--target-host", dest='host', type=str, default="127.0.0.1", help="set the target host receive access token")
@@ -493,7 +499,7 @@ def main():
             deleteBootParams(bss_url, headers, cacert, bss_dict)
         elif args.get_bootparams:
             bss = getBSS(bss_url, headers, cacert)
-            printBSS(smd_url, bss, headers, cacert, args.raw)
+            printBSS(smd_url, bss, headers, cacert, args.format)
     
     elif args.command == "login":
         url = args.url

--- a/ochami-cli
+++ b/ochami-cli
@@ -24,11 +24,11 @@ def readConfig(cfile):
 
 
 def makeRequest(url, r_type, headers, jdata=None, cert=cacert):
-    if r_type is "get":
+    if r_type == "get":
         r = requests.get(url, json = jdata, headers=headers, verify=cert)
-    elif r_type is "post":
+    elif r_type == "post":
         r = requests.post(url, json = jdata, headers=headers, verify=cert)
-    elif r_type is "delete":
+    elif r_type == "delete":
         r = requests.delete(url, json = jdata, headers=headers, verify=cert)
 
     else:
@@ -211,24 +211,28 @@ def getXnameFromNid(smd_url, headers, cert, nid):
 
 ############# BSS #############
 
-def printBSS(smd_url, bss_data, headers, cert):
+def printBSS(smd_url, bss_data, headers, cert, raw):
     data = getNidMacMap(smd_url, headers, cert)
-    for b in bss_data:
-        pdata = {}
-        pdata['nids'] = NodeSet()
-        pdata['kernel'] = b['kernel']
-        pdata['initrd'] = b['initrd']
-        pdata['params'] = b['params']
-        max_nid = max(data.values())
-        nid_length = len(str(max_nid))
-        for m in b['macs']:
-            nid = cluster_prefix+str(data[m]).zfill(nid_length)
-            pdata['nids'].update(nid)
-        print("nodes:", pdata['nids'])
-        print("kernel: ", pdata['kernel'])
-        print("initrd: ", pdata['initrd'])
-        print("params: ", pdata['params'])
-        print()
+    if raw:
+        json_formatted_str = json.dumps(bss_data, indent=2)
+        print(json_formatted_str)
+    else:
+        for b in bss_data:
+            pdata = {}
+            pdata['nids'] = NodeSet()
+            pdata['kernel'] = b['kernel']
+            pdata['initrd'] = b['initrd']
+            pdata['params'] = b['params']
+            max_nid = max(data.values())
+            nid_length = len(str(max_nid))
+            for m in b['macs']:
+                nid = cluster_prefix+str(data[m]).zfill(nid_length)
+                pdata['nids'].update(nid)
+            print("nodes:", pdata['nids'])
+            print("kernel: ", pdata['kernel'])
+            print("initrd: ", pdata['initrd'])
+            print("params: ", pdata['params'])
+            print()
 
 def getBSS(bss_url, headers, cert):
     data = makeRequest(url=bss_url+'/bootparameters', r_type='get', headers=headers, cert=cert)
@@ -383,6 +387,7 @@ def setArgs():
     bss.add_argument('--kernel', type=str)
     bss.add_argument('--initrd', type=str)
     bss.add_argument('--params', type=str)
+    bss.add_argument('--raw', action="store_true", default=False)
     login = subparser.add_parser('login')
     login.add_argument("--url", type=str, default="http://127.0.0.1:3333/login", help="set the login URL")
     login.add_argument("--target-host", dest='host', type=str, default="127.0.0.1", help="set the target host receive access token")
@@ -488,7 +493,7 @@ def main():
             deleteBootParams(bss_url, headers, cacert, bss_dict)
         elif args.get_bootparams:
             bss = getBSS(bss_url, headers, cacert)
-            printBSS(smd_url, bss, headers, cacert)
+            printBSS(smd_url, bss, headers, cacert, args.raw)
     
     elif args.command == "login":
         url = args.url

--- a/ochami-cli
+++ b/ochami-cli
@@ -509,11 +509,12 @@ def main():
                     headers = {"Authorization": f"Bearer {access_token}"}
 
     # Check Token
-    if not access_token:
-        print("ERROR: Neither --access-token, --access-token-file, nor ACCESS_TOKEN were set.")
-        sys.exit(1)
-    if not checkTokenExpired(access_token):
-        sys.exit(1)
+    if args.command != "login":
+        if not access_token:
+            print("ERROR: Neither --access-token, --access-token-file, nor ACCESS_TOKEN were set.")
+            sys.exit(1)
+        if not checkTokenExpired(access_token):
+            sys.exit(1)
     
     # set CA cert var
     if os.getenv("CACERT"):

--- a/ochami-cli
+++ b/ochami-cli
@@ -142,11 +142,13 @@ def addRedfishEndpoint(smd_url, headers, cert, name, xname, mac, bmc_ipaddr):
     re = redfishEndpointPayload({'name': name, 'xname': xname, 'mac': mac, 'bmc_ipaddr': bmc_ipaddr})
     makeRequest(url=smd_url+'/Inventory/RedfishEndpoints', r_type='post', headers=headers, cert=cert, jdata=re)
 
-def getSMDComponents(smd_url, headers, cert, xname):
-    if not xname:
+def getSMDComponents(smd_url, headers, cert, xname, nid):
+    if not xname and not nid:
         data = makeRequest(url=smd_url+'/State/Components', r_type='get', headers=headers, cert=cert)
-    else:
+    elif xname:
         data = makeRequest(url=smd_url+'/State/Components/'+xname, r_type='get', headers=headers, cert=cert)
+    elif nid:
+        data = makeRequest(url=smd_url+'/State/Components?nid='+nid, r_type='get', headers=headers, cert=cert)
     return data
 
 def getSMDInterfaces(smd_url, headers, cert, xname):
@@ -172,6 +174,20 @@ def getMacFromXname(smd_url, headers, cert, xname):
                 if 'MACAddress' in s:
                     mac_list.append(s['MACAddress'])
     return mac_list
+
+def getNidFromXname(smd_url, headers, cert, xname):
+    data = makeRequest(url=smd_url+'/State/Components/'+xname, r_type='get', headers=headers, cert=cert)
+    if 'NID' in data:
+        return data['NID']
+    return None
+
+def getXnameFromNid(smd_url, headers, cert, nid):
+    data = makeRequest(url=smd_url+'/State/Components?nid='+nid, r_type='get', headers=headers, cert=cert)
+    for d in data['Components']:
+        if 'ID' in d:
+            return d['ID']
+    return None
+
 ############# SMD #############
 
 
@@ -194,7 +210,9 @@ def updateBootParams(bss_url, headers, cert, bss_data):
 def deleteBootParams(bss_url, headers, cert, bss_data):
     makeRequest(url=bss_url+'/bootparameters', r_type='delete', jdata=bss_data, headers=headers, cert=cert)
 
-def setBootParams(smd_url, bss_url, headers, cert, xname, image, kernel, initrd, params):
+def setBootParams(smd_url, bss_url, headers, cert, xname, nid, image, kernel, initrd, params):
+    if nid:
+        xname = getXnameFromNid(smd_url, headers, cert, nid)
     macs = getMacFromXname(smd_url, headers, cert, xname)
     bss_query = '?mac=' + ','.join(macs)
     bdata = getBSSfiltered(bss_url, bss_query, headers, cert)
@@ -322,6 +340,7 @@ def setArgs():
     bss.add_argument('--delete-bootparams', dest='delete_bootparams', action="store_true", default=False)
     bss.add_argument('--get-bootparams', dest='get_bootparams', action="store_true", default=False)
     bss.add_argument('--xname', type=str)
+    bss.add_argument('--nid', type=str)
     bss.add_argument('--image', type=str)
     bss.add_argument('--kernel', type=str)
     bss.add_argument('--initrd', type=str)
@@ -400,7 +419,7 @@ def main():
         elif args.add_rf_endpoint:
             addRedfishEndpoint(smd_url, headers, cacert, args.name, args.xname, args.mac, args.bmc_ipaddr)
         elif args.get_components:
-            sc = getSMDComponents(smd_url, headers, cacert, args.xname)
+            sc = getSMDComponents(smd_url, headers, cacert, args.xname, args.nid)
             json_formatted_str = json.dumps(sc, indent=2)
             print(json_formatted_str)
         elif args.get_interfaces:
@@ -420,7 +439,7 @@ def main():
                 updateBootParams(bss_url, headers, cacert, bss_dict)
             else:
                 if args.image or args.kernel or args.initrd or args.params:
-                    setBootParams(smd_url, bss_url, headers, cacert, args.xname, args.image, args.kernel, args.initrd, args.params)
+                    setBootParams(smd_url, bss_url, headers, cacert, args.xname, args.nid, args.image, args.kernel, args.initrd, args.params)
         elif args.delete_bootparams:
             deleteBootParams(bss_url, headers, cacert, bss_dict)
         elif args.get_bootparams:


### PR DESCRIPTION
Updates and add BSS commands.

Should now be possible to set `--image`, `--kernel`, `--initrd`, `--params` on the cmdline with `--update-bootparams`. 
All or one can be specified. Anything not set will use the current value in BSS. Can also specify an xname with `--xname` or a nid number `--nid`

example:
```
ochami-cli bss --update-bootparams --nid 002 --image root=nfs:192.168.7.253:/exports/netroot/almalinux8.9
```

Getting the current BSS data will now print in a more readable format. 
```
[root@ochami-vm ochami-cmdline]# ochami-cli bss --get-bootparams
nodes: nid[003-660]
kernel:  http://192.168.7.253:9000/boot-images/efi-images/compute/vmlinuz-4.18.0-513.24.1.el8_9.x86_64
initrd:  http://192.168.7.253:9000/boot-images/efi-images/compute/initramfs-4.18.0-513.24.1.el8_9.x86_64.img
params:  nomodeset ro ip=dhcp apparmor=0 selinux=0 console=ttyS0,115200 ip6=off ds=nocloud-net;s=http://192.168.7.253:8000/compute/ network-config=disabled rd.shell root=nfs:192.168.7.253:/exports/netroot/almalinux8.9-ib

nodes: nid[001-002]
kernel:  http://192.168.7.253:9000/boot-images/efi-images/compute/vmlinuz-4.18.0-513.24.1.el8_9.x86_64
initrd:  http://192.168.7.253:9000/boot-images/efi-images/compute/initramfs-4.18.0-513.24.1.el8_9.x86_64.img
params:  nomodeset ro ip=dhcp apparmor=0 selinux=0 console=ttyS0,115200 ip6=off ds=nocloud-net;s=http://192.168.7.253:8000/compute/ network-config=disabled rd.shell root=nfs:192.168.7.253:/exports/netroot/almalinux8.9
```
This will make `ClusterShell` a dependency, which can easily be installed with `pip`